### PR TITLE
Improve li element handling of wrapped blocks

### DIFF
--- a/sample/code.md
+++ b/sample/code.md
@@ -1,0 +1,29 @@
+Code block outside:
+
+    @lang:c
+    int main(void) {
+        return 0;
+    }
+
+Code block inside blockquote:
+
+>     @lang:c
+>     int main(void) {
+>         return 0;
+>     }
+
+Code block inside list:
+
+ - here:
+
+        @lang:c
+        int main(void) {
+            return 0;
+        }
+
+ 1. or here:
+
+        @lang:c
+        int main(void) {
+            return 0;
+        }


### PR DESCRIPTION
<li> elements kind of mess up the indentation of code blocks inside them, which is a symptom of a bigger problem. The fact that list elements can contain both inline and block elements means that only inline content should be wrapped, while block content should be embedded as-is inside the list element's render block.
